### PR TITLE
Use new_event_loop() instead of get_event_loop()

### DIFF
--- a/checkDataQuality.py
+++ b/checkDataQuality.py
@@ -372,5 +372,5 @@ async def main(argv):
 
     print()
 
-loop=asyncio.get_event_loop()
+loop=asyncio.new_event_loop()
 loop.run_until_complete(main(sys.argv[1:]))


### PR DESCRIPTION
`get_event_loop()` emits a deprecation warning since Python 3.10 if there is no running event loop; `new_event_loop()` was already in Python 3.6, so this should have no impact on compatibility. (`asyncio.run()` is recommended, but was only added in Python 3.7.)